### PR TITLE
fix: `ZenBTCParams` nil checks (#91)

### DIFF
--- a/x/validation/keeper/hv_params.go
+++ b/x/validation/keeper/hv_params.go
@@ -78,12 +78,18 @@ func (k Keeper) GetZenBTCEthBatcherAddr(ctx context.Context) string {
 	if err != nil {
 		return DefaultZenBTCEthBatcherAddr
 	}
+	if params.ZenBTCParams == nil {
+		return DefaultZenBTCEthBatcherAddr
+	}
 	return params.ZenBTCParams.ZenBTCEthBatcherAddr
 }
 
 func (k Keeper) GetZenBTCDepositKeyringAddr(ctx context.Context) string {
 	params, err := k.HVParams.Get(ctx)
 	if err != nil {
+		return DefaultZenBTCDepositKeyringAddr
+	}
+	if params.ZenBTCParams == nil {
 		return DefaultZenBTCDepositKeyringAddr
 	}
 	return params.ZenBTCParams.ZenBTCDepositKeyringAddr
@@ -94,12 +100,18 @@ func (k Keeper) GetZenBTCMinterKeyID(ctx context.Context) uint64 {
 	if err != nil {
 		return DefaultZenBTCMinterKeyID
 	}
+	if params.ZenBTCParams == nil {
+		return DefaultZenBTCMinterKeyID
+	}
 	return params.ZenBTCParams.ZenBTCMinterKeyID
 }
 
 func (k Keeper) GetZenBTCUnstakerKeyID(ctx context.Context) uint64 {
 	params, err := k.HVParams.Get(ctx)
 	if err != nil {
+		return DefaultZenBTCUnstakerKeyID
+	}
+	if params.ZenBTCParams == nil {
 		return DefaultZenBTCUnstakerKeyID
 	}
 	return params.ZenBTCParams.ZenBTCUnstakerKeyID
@@ -118,12 +130,18 @@ func (k Keeper) GetZenBTCWithdrawerKeyID(ctx context.Context) uint64 {
 	if err != nil {
 		return DefaultZenBTCWithdrawerKeyID
 	}
+	if params.ZenBTCParams == nil {
+		return DefaultZenBTCWithdrawerKeyID
+	}
 	return params.ZenBTCParams.ZenBTCWithdrawerKeyID
 }
 
 func (k Keeper) GetBitcoinProxyCreatorID(ctx context.Context) string {
 	params, err := k.HVParams.Get(ctx)
 	if err != nil {
+		return DefaultBitcoinProxyCreatorID
+	}
+	if params.ZenBTCParams == nil {
 		return DefaultBitcoinProxyCreatorID
 	}
 	return params.ZenBTCParams.BitcoinProxyCreatorID
@@ -134,6 +152,9 @@ func (k Keeper) GetZenBTCChangeAddressKeyIDs(ctx context.Context) []uint64 {
 	if err != nil {
 		return DefaultZenBTCChangeAddressKeyIDs
 	}
+	if params.ZenBTCParams == nil {
+		return DefaultZenBTCChangeAddressKeyIDs
+	}
 	return params.ZenBTCParams.ZenBTCChangeAddressKeyIDs
 }
 
@@ -142,12 +163,18 @@ func (k Keeper) GetZenBTCRewardsDepositKeyID(ctx context.Context) uint64 {
 	if err != nil {
 		return DefaultZenBTCRewardsDepositKeyID
 	}
+	if params.ZenBTCParams == nil {
+		return DefaultZenBTCRewardsDepositKeyID
+	}
 	return params.ZenBTCParams.ZenBTCRewardsDepositKeyID
 }
 
 func (k Keeper) GetStakeableAssets(ctx context.Context) []*types.AssetData {
 	params, err := k.HVParams.Get(ctx)
 	if err != nil {
+		return DefaultStakeableAssets
+	}
+	if params.ZenBTCParams == nil {
 		return DefaultStakeableAssets
 	}
 	return params.ZenBTCParams.StakeableAssets

--- a/x/validation/migrations/v6/store.go
+++ b/x/validation/migrations/v6/store.go
@@ -39,11 +39,11 @@ func UpdateParams(ctx sdk.Context, params collections.Item[types.HVParams]) erro
 			ZenBTCParams: &types.ZenBTCParams{
 				ZenBTCEthBatcherAddr:      "0x912D79F8d489d0d007aBE0E26fD5d2f06BA4A2AA",
 				ZenBTCDepositKeyringAddr:  "keyring1hpyh7xqr2w7h4eas5y8twnsg",
-				ZenBTCWithdrawerKeyID:     29,
-				ZenBTCMinterKeyID:         30,
-				ZenBTCChangeAddressKeyIDs: []uint64{31},
-				ZenBTCUnstakerKeyID:       32,
-				ZenBTCRewardsDepositKeyID: 33,
+				ZenBTCWithdrawerKeyID:     25,
+				ZenBTCMinterKeyID:         27,
+				ZenBTCChangeAddressKeyIDs: []uint64{26},
+				ZenBTCUnstakerKeyID:       28,
+				ZenBTCRewardsDepositKeyID: 29,
 				BitcoinProxyCreatorID:     "zen13y3tm68gmu9kntcxwvmue82p6akacnpt2v7nty",
 				StakeableAssets: []*types.AssetData{
 					{Asset: types.Asset_ROCK, Precision: 6, PriceUSD: math.LegacyZeroDec()},


### PR DESCRIPTION
* fix: configure bitcoin network based on zrchain chainID

* fix: restrict use of zenBTC keys to bitcoin proxy only

* fix tests

* fix tests

* use dynamic fee tx for minting

* refactor eth tx construction, update init.sh

* chore: validation v6 upgrade files

* add migration + test file

* wip

* fix migration tests

* disable faulty test cases

* fix: zenbtc params during upgrade

* update store migration file

---------