### PR TITLE
fix: bump ver to update store migration keyIDs `zenbtc` (#129)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
-	github.com/zenrocklabs/zenbtc v1.7.16
+	github.com/zenrocklabs/zenbtc v1.7.17
 	github.com/zenrocklabs/zenrock-avs v1.4.14
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
 	golang.org/x/tools v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -1306,8 +1306,8 @@ github.com/zenrocklabs/cosmos-sdk v0.50.10-zenrock h1:QKr8fWJ85qM/mcnKRQfsem6cNZ
 github.com/zenrocklabs/cosmos-sdk v0.50.10-zenrock/go.mod h1:6Eesrx3ZE7vxBZWpK++30H+Uc7Q4ahQWCL7JKU/LEdU=
 github.com/zenrocklabs/eigensdk-go v0.1.7-zenrock2 h1:mip7GbIne2Aneeoe3MsaestQoqcXVA7LSXq/6ztw97Q=
 github.com/zenrocklabs/eigensdk-go v0.1.7-zenrock2/go.mod h1:ECU8/Ocsf+dGcN2rs8I1PScq4dOkQqY+vgwnq30Ov4M=
-github.com/zenrocklabs/zenbtc v1.7.16 h1:FfPva5wp0W5sKKBZ6wYePcvIlSJuYUblC5DjyPqUrEk=
-github.com/zenrocklabs/zenbtc v1.7.16/go.mod h1:8hJWjWorXxjq68mFdLAqJOk6yI57cSGRHQGpisrlu18=
+github.com/zenrocklabs/zenbtc v1.7.17 h1:WCQs+apdfsj03JG2eYNVd3v/goBwclWQOOYCvzLZu5o=
+github.com/zenrocklabs/zenbtc v1.7.17/go.mod h1:vW8q1xTipMQnQCWsqU1QfKBk/qpFC3HMav6Lq6906pM=
 github.com/zenrocklabs/zenrock-avs v1.4.14 h1:KOpx7SBk839s81+Icq4DqF84+AkP0ryBEOcNKKYubv0=
 github.com/zenrocklabs/zenrock-avs v1.4.14/go.mod h1:1TZzdlC+ZczhvS5tOc1ShRy2rwqHWhONd0dhB+GPTRE=
 github.com/zondax/hid v0.9.2 h1:WCJFnEDMiqGF64nlZz28E9qLVZ0KSJ7xpc5DLEyma2U=


### PR DESCRIPTION
* fix: bump ver to update store migration keyIDs `zenbtc`

* go mod tidy