### PR TITLE
feat: use `msgpack` encoding VE flow, support all networks `vote-exam…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ run-sidecar:
 	cd sidecar && ./sidecar
 
 run-alt-sidecar:
-	cd sidecar && ./sidecar --port 9393 --cache-file cache_alt.json --neutrino-port 54321 --eth-rpc https://rpc.ankr.com/eth_holesky --neutrino-path /neutrino_alt_
+	cd sidecar && ./sidecar --port 9393 --cache-file cache_alt.json --neutrino-port 54321 --neutrino-path /neutrino_alt_
 
 sidecar: build-sidecar run-sidecar
 

--- a/sidecar/server.go
+++ b/sidecar/server.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"net"
@@ -10,6 +9,7 @@ import (
 	"github.com/Zenrock-Foundation/zrchain/v5/sidecar/proto/api"
 	sidecartypes "github.com/Zenrock-Foundation/zrchain/v5/sidecar/shared"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/shamaton/msgpack/v2"
 	"google.golang.org/grpc"
 )
 
@@ -41,7 +41,7 @@ func NewOracleService(oracle *Oracle) *oracleService {
 func (s *oracleService) GetSidecarState(ctx context.Context, req *api.SidecarStateRequest) (*api.SidecarStateResponse, error) {
 	currentState := s.oracle.currentState.Load().(*sidecartypes.OracleState)
 
-	contractState, err := json.Marshal(currentState.EigenDelegations)
+	contractState, err := msgpack.Marshal(currentState.EigenDelegations)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal state: %w", err)
 	}
@@ -67,7 +67,7 @@ func (s *oracleService) GetSidecarStateByEthHeight(ctx context.Context, req *api
 		return nil, err
 	}
 
-	contractState, err := json.Marshal(state.EigenDelegations)
+	contractState, err := msgpack.Marshal(state.EigenDelegations)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal state: %w", err)
 	}

--- a/utils/vote-examiner/main.go
+++ b/utils/vote-examiner/main.go
@@ -18,6 +18,9 @@ import (
 func main() {
 	config := parseFlags()
 
+	// Display selected network info
+	fmt.Printf("Using %s network (%s)\n", config.Network, config.RPCNode)
+
 	// Get validator information
 	fmt.Println("Fetching validator information...")
 	addrToMoniker, err := buildValidatorMappings(config.RPCNode)
@@ -41,14 +44,34 @@ func main() {
 // parseFlags parses command line flags and returns a Config
 func parseFlags() Config {
 	useFileFlag := flag.String("file", "", "Use file instead of executing command (optional)")
-	rpcNodeFlag := flag.String("node", "https://rpc.diamond.zenrocklabs.io:443", "RPC node URL")
+	networkFlag := flag.String("network", "mainnet", "Network to use: devnet, testnet, or mainnet (default: mainnet)")
+	rpcNodeFlag := flag.String("node", "", "RPC node URL (overrides network selection)")
 	blockHeightFlag := flag.String("height", "", "Block height (default: latest)")
 	missingOnlyFlag := flag.Bool("missing-only", false, "Only show validators missing vote extensions")
 	flag.Parse()
 
+	// Map network to RPC URL if node is not explicitly provided
+	rpcURL := *rpcNodeFlag
+	if rpcURL == "" {
+		switch *networkFlag {
+		case "devnet", "dev", "amber":
+			rpcURL = "https://rpc.dev.zenrock.tech:443"
+		case "testnet", "test", "gardia":
+			rpcURL = "https://rpc.gardia.zenrocklabs.io:443"
+		case "mainnet", "main", "diamond":
+			rpcURL = "https://rpc.diamond.zenrocklabs.io:443"
+		default:
+			// Default to mainnet if unrecognized network
+			fmt.Printf("Warning: Unrecognized network '%s', defaulting to mainnet\n", *networkFlag)
+			*networkFlag = "mainnet"
+			rpcURL = "https://rpc.diamond.zenrocklabs.io:443"
+		}
+	}
+
 	return Config{
 		UseFile:     *useFileFlag,
-		RPCNode:     *rpcNodeFlag,
+		RPCNode:     rpcURL,
+		Network:     *networkFlag,
 		BlockHeight: *blockHeightFlag,
 		MissingOnly: *missingOnlyFlag,
 	}
@@ -430,18 +453,44 @@ func printDifferences(differences map[string]map[string][]ValidatorInfo, validat
 		return
 	}
 
-	// Sort keys for consistent output
-	sortedKeys := make([]string, 0, len(differences))
-	for k := range differences {
-		sortedKeys = append(sortedKeys, k)
+	// Create a slice of keys with their consensus percentages
+	type fieldConsensus struct {
+		key              string
+		consensusPercent float64
 	}
-	sort.Strings(sortedKeys)
 
-	for _, key := range sortedKeys {
-		fmt.Printf("\nDifferences in field: %s\n", key)
+	fieldsByConsensus := make([]fieldConsensus, 0, len(differences))
+
+	for key, valueMap := range differences {
+		// Find highest consensus for this field
+		highestConsensus := 0.0
+		for _, vals := range valueMap {
+			thisPower := 0
+			for _, val := range vals {
+				thisPower += val.Power
+			}
+			consensusPercent := float64(thisPower) / float64(totalPower) * 100
+			if consensusPercent > highestConsensus {
+				highestConsensus = consensusPercent
+			}
+		}
+
+		fieldsByConsensus = append(fieldsByConsensus, fieldConsensus{
+			key:              key,
+			consensusPercent: highestConsensus,
+		})
+	}
+
+	// Sort by consensus percentage (ascending - lowest consensus last)
+	sort.Slice(fieldsByConsensus, func(i, j int) bool {
+		return fieldsByConsensus[i].consensusPercent > fieldsByConsensus[j].consensusPercent
+	})
+
+	for _, field := range fieldsByConsensus {
+		fmt.Printf("\nDifferences in field: %s (highest consensus: %.2f%%)\n", field.key, field.consensusPercent)
 		fmt.Printf("-------------------------\n")
 
-		valueMap := differences[key]
+		valueMap := differences[field.key]
 		printValueDifferences(valueMap, validators, totalPower)
 	}
 }

--- a/utils/vote-examiner/types.go
+++ b/utils/vote-examiner/types.go
@@ -78,6 +78,7 @@ type ValidatorsResponse struct {
 type Config struct {
 	UseFile     string
 	RPCNode     string
+	Network     string
 	BlockHeight string
 	MissingOnly bool
 }

--- a/x/validation/keeper/abci_types.go
+++ b/x/validation/keeper/abci_types.go
@@ -3,7 +3,6 @@ package keeper
 import (
 	"context"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -14,6 +13,7 @@ import (
 	sidecar "github.com/Zenrock-Foundation/zrchain/v5/sidecar/proto/api"
 	abci "github.com/cometbft/cometbft/abci/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/shamaton/msgpack/v2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
@@ -49,9 +49,9 @@ type (
 		SolanaRecentBlockhash      string
 		EthBurnEventsHash          []byte
 		RedemptionsHash            []byte
-		ROCKUSDPrice               math.LegacyDec
-		BTCUSDPrice                math.LegacyDec
-		ETHUSDPrice                math.LegacyDec
+		ROCKUSDPrice               string
+		BTCUSDPrice                string
+		ETHUSDPrice                string
 		LatestBtcBlockHeight       int64
 		LatestBtcHeaderHash        []byte
 	}
@@ -80,9 +80,9 @@ type (
 		SolanaRecentBlockhash      string
 		EthBurnEvents              []api.BurnEvent
 		Redemptions                []api.Redemption
-		ROCKUSDPrice               math.LegacyDec
-		BTCUSDPrice                math.LegacyDec
-		ETHUSDPrice                math.LegacyDec
+		ROCKUSDPrice               string
+		BTCUSDPrice                string
+		ETHUSDPrice                string
 		ConsensusData              abci.ExtendedCommitInfo
 		FieldVotePowers            map[VoteExtensionField]int64 // Track which fields reached consensus
 	}
@@ -174,16 +174,16 @@ func (ve VoteExtension) IsInvalid(logger log.Logger) bool {
 		logger.Error("invalid vote extension: RedemptionsHash is empty")
 		invalid = true
 	}
-	if ve.ROCKUSDPrice.IsNil() || ve.ROCKUSDPrice.IsZero() {
-		logger.Error("invalid vote extension: ROCKUSDPrice is nil or zero")
+	if ve.ROCKUSDPrice == "" {
+		logger.Error("invalid vote extension: ROCKUSDPrice is empty")
 		invalid = true
 	}
-	if ve.BTCUSDPrice.IsNil() || ve.BTCUSDPrice.IsZero() {
-		logger.Error("invalid vote extension: BTCUSDPrice is nil or zero")
+	if ve.BTCUSDPrice == "" {
+		logger.Error("invalid vote extension: BTCUSDPrice is empty")
 		invalid = true
 	}
-	if ve.ETHUSDPrice.IsNil() || ve.ETHUSDPrice.IsZero() {
-		logger.Error("invalid vote extension: ETHUSDPrice is nil or zero")
+	if ve.ETHUSDPrice == "" {
+		logger.Error("invalid vote extension: ETHUSDPrice is empty")
 		invalid = true
 	}
 	if ve.LatestBtcBlockHeight == 0 {
@@ -290,7 +290,7 @@ type fieldVote struct {
 	votePower int64
 }
 
-// genericGetKey marshals a value to JSON for use as a map key
+// genericGetKey marshals a value to bytes for use as a map key
 func genericGetKey(value any) string {
 	if value == nil {
 		return ""
@@ -301,8 +301,8 @@ func genericGetKey(value any) string {
 		return hex.EncodeToString(byteSlice)
 	}
 
-	// For other types, use JSON
-	bytes, err := json.Marshal(value)
+	// For other types, use msgpack
+	bytes, err := msgpack.Marshal(value)
 	if err != nil {
 		// Fall back to string representation if marshaling fails
 		return fmt.Sprintf("%v", value)
@@ -456,17 +456,17 @@ func initializeFieldHandlers() []FieldHandler {
 		{
 			Field:    VEFieldROCKUSDPrice,
 			GetValue: func(ve VoteExtension) any { return ve.ROCKUSDPrice },
-			SetValue: func(v any, ve *VoteExtension) { ve.ROCKUSDPrice = v.(math.LegacyDec) },
+			SetValue: func(v any, ve *VoteExtension) { ve.ROCKUSDPrice = v.(string) },
 		},
 		{
 			Field:    VEFieldBTCUSDPrice,
 			GetValue: func(ve VoteExtension) any { return ve.BTCUSDPrice },
-			SetValue: func(v any, ve *VoteExtension) { ve.BTCUSDPrice = v.(math.LegacyDec) },
+			SetValue: func(v any, ve *VoteExtension) { ve.BTCUSDPrice = v.(string) },
 		},
 		{
 			Field:    VEFieldETHUSDPrice,
 			GetValue: func(ve VoteExtension) any { return ve.ETHUSDPrice },
-			SetValue: func(v any, ve *VoteExtension) { ve.ETHUSDPrice = v.(math.LegacyDec) },
+			SetValue: func(v any, ve *VoteExtension) { ve.ETHUSDPrice = v.(string) },
 		},
 	}
 }

--- a/x/validation/keeper/zenbtc_mint_fee_test.go
+++ b/x/validation/keeper/zenbtc_mint_fee_test.go
@@ -38,7 +38,7 @@ func TestCalculateZenBTCMintFee(t *testing.T) {
 			btcUSDPrice:  sdkmath.LegacyNewDec(90_000_00), // $90k BTC in cents
 			ethUSDPrice:  sdkmath.LegacyNewDec(3_000_00),  // $3k ETH in cents
 			exchangeRate: sdkmath.LegacyNewDec(1),
-			expected:     30399, // 0.00030399 BTC in fees (1:1 exchange rate)
+			expected:     30400, // 0.000304 BTC in fees (1:1 exchange rate)
 		},
 		{
 			name:         "high gas price scenario",
@@ -48,7 +48,7 @@ func TestCalculateZenBTCMintFee(t *testing.T) {
 			btcUSDPrice:  sdkmath.LegacyNewDec(90_000_00),
 			ethUSDPrice:  sdkmath.LegacyNewDec(3_000_00),
 			exchangeRate: sdkmath.LegacyNewDec(1),
-			expected:     99749, // 0.00099749 BTC in fees (1:1 exchange rate)
+			expected:     99750, // 0.0009975 BTC in fees (1:1 exchange rate)
 		},
 	}
 


### PR DESCRIPTION
…iner`, order results by vote-share, improve zenbtc fee calc (#207)

* fix: order vote-examiner output by descending consensus %

* feat: support all networks `vote-examiner`

* feat: use msgpack instead of JSON for marshaling VE flow

* improve fee calculation precision

* wip

* fix msgpack impl

* refactor `updateAssetPrices`

* cleanup

* cleanup

* update ordering for legibility