### PR TITLE
fix: re-enable solana impl with fixes + logging

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -4,11 +4,11 @@ import (
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 
 	"github.com/Zenrock-Foundation/zrchain/v6/app/upgrades"
-	v6 "github.com/Zenrock-Foundation/zrchain/v6/app/upgrades/v6"
+	"github.com/Zenrock-Foundation/zrchain/v6/app/upgrades/v6rev1"
 )
 
 var Upgrades = []upgrades.Upgrade{
-	v6.Upgrade,
+	v6rev1.Upgrade,
 }
 
 func (app ZenrockApp) RegisterUpgradeHandlers() {

--- a/app/upgrades/v6rev1/constants.go
+++ b/app/upgrades/v6rev1/constants.go
@@ -1,0 +1,18 @@
+package v6rev1
+
+import (
+	storetypes "cosmossdk.io/store/types"
+	"github.com/Zenrock-Foundation/zrchain/v6/app/upgrades"
+)
+
+const UpgradeName = "v6rev1"
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades: storetypes.StoreUpgrades{
+		Added:   []string{},
+		Deleted: []string{},
+		Renamed: []storetypes.StoreRename{},
+	},
+}

--- a/app/upgrades/v6rev1/upgrade.go
+++ b/app/upgrades/v6rev1/upgrade.go
@@ -1,0 +1,19 @@
+package v6rev1
+
+import (
+	"context"
+
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+)
+
+func CreateUpgradeHandler(mm *module.Manager, configurator module.Configurator) upgradetypes.UpgradeHandler {
+	return func(context context.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		ctx := sdk.UnwrapSDKContext(context)
+		logger := ctx.Logger().With("upgrade", UpgradeName)
+		logger.Debug("starting upgrade")
+
+		return mm.RunMigrations(ctx, configurator, vm)
+	}
+}

--- a/contracts/solrock/burn_test.go
+++ b/contracts/solrock/burn_test.go
@@ -1,0 +1,56 @@
+package solrock
+
+// import (
+// 	"context"
+// 	"encoding/hex"
+// 	"fmt"
+// 	"testing"
+
+// 	"github.com/Zenrock-Foundation/zrchain/v6/contracts/solrock/generated/rock_spl_token"
+// 	sdk "github.com/cosmos/cosmos-sdk/types"
+// 	"github.com/gagliardetto/solana-go"
+// 	"github.com/gagliardetto/solana-go/rpc"
+// 	"github.com/stretchr/testify/require"
+// )
+
+// func TestBurn(t *testing.T) {
+// 	signer, err := solana.PublicKeyFromBase58("5pVWFKJtfA52zJZ9zeHVSn1CzSZJAMGG82iS8VYwfyV5")
+// 	require.NoError(t, err)
+// 	feeWallet, err := solana.PublicKeyFromBase58("FzqGcRG98v1KhKxatX2Abb2z1aJ2rViQwBK5GHByKCAd")
+// 	require.NoError(t, err)
+// 	value := uint64(50)
+// 	alice := "zen13y3tm68gmu9kntcxwvmue82p6akacnpt2v7nty"
+// 	aliceBytes, err := sdk.GetFromBech32(alice, "zen")
+// 	require.NoError(t, err)
+// 	aliceAddress := [25]byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+// 		0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+// 		0xFF, 0xFF, 0xFF, 0xFF, 0xFF}
+// 	copy(aliceAddress[:], aliceBytes)
+
+// 	var client = rpc.New("https://api.devnet.solana.com")
+
+// 	recent, err := client.GetLatestBlockhash(context.Background(), rpc.CommitmentConfirmed)
+// 	require.NoError(t, err)
+
+// 	tx, err := solana.NewTransaction(
+// 		[]solana.Instruction{
+// 			Unwrap(
+// 				programID,
+// 				rock_spl_token.UnwrapArgs{
+// 					Value:    value,
+// 					DestAddr: aliceAddress,
+// 				},
+// 				signer,
+// 				mintAddress,
+// 				feeWallet,
+// 			),
+// 		},
+// 		recent.Value.Blockhash,
+// 		solana.TransactionPayer(signer),
+// 	)
+// 	require.NoError(t, err)
+// 	require.NoError(t, err)
+// 	bin, err := tx.Message.MarshalBinary()
+// 	require.NoError(t, err)
+// 	fmt.Printf("transaction : %s", hex.EncodeToString(bin))
+// }

--- a/create_keys.sh
+++ b/create_keys.sh
@@ -13,6 +13,7 @@ key_types=(
 	"ed25519"  #10
 	"ed25519"  #11
         "ed25519"  #12
+        "ed25519"  #13
 ) 
 
 workspace="workspace14a2hpadpsy9h4auve2z8lw"

--- a/init.sh
+++ b/init.sh
@@ -178,7 +178,8 @@ if [ "$START_ONLY" = false ]; then
           "nonce_account_key": 9,
           "mint_address": "StVNdHNSFK3uVTL5apWHysgze4M8zrsqwjEAH1JM87i",
           "fee_wallet": "FzqGcRG98v1KhKxatX2Abb2z1aJ2rViQwBK5GHByKCAd",
-          "fee": 20
+          "fee": 20,
+          "btl": 21
         }
     }' $HOME_DIR/config/genesis.json > tmp_genesis.json && mv tmp_genesis.json $HOME_DIR/config/genesis.json
     function ssed {

--- a/sidecar/oracle.go
+++ b/sidecar/oracle.go
@@ -176,18 +176,18 @@ func (o *Oracle) fetchAndProcessState(
 	}()
 
 	// Fetch Solana lamports per signature
-	// wg.Add(1)
-	// go func() {
-	// 	defer wg.Done()
-	// 	lamportsPerSignature, err := o.getSolanaLamportsPerSignature(ctx)
-	// 	if err != nil {
-	// 		errChan <- fmt.Errorf("failed to get Solana lamports per signature: %w", err)
-	// 		return
-	// 	}
-	// 	updateMutex.Lock()
-	// 	update.solanaLamportsPerSignature = lamportsPerSignature
-	// 	updateMutex.Unlock()
-	// }()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		lamportsPerSignature, err := o.getSolanaLamportsPerSignature(ctx)
+		if err != nil {
+			errChan <- fmt.Errorf("failed to get Solana lamports per signature: %w", err)
+			return
+		}
+		updateMutex.Lock()
+		update.solanaLamportsPerSignature = lamportsPerSignature
+		updateMutex.Unlock()
+	}()
 
 	// Estimate gas for stake call
 	wg.Add(1)
@@ -289,62 +289,62 @@ func (o *Oracle) fetchAndProcessState(
 	}()
 
 	// Fetch SolROCK Mints
-	// wg.Add(1)
-	// go func() {
-	// 	defer wg.Done()
-	// 	// TODO: put id in config
-	// 	events, err := o.getSolROCKMints(sidecartypes.SolRockProgramID[o.Config.Network])
-	// 	if err != nil {
-	// 		errChan <- fmt.Errorf("failed to process SolROCK mint events: %w", err)
-	// 		return
-	// 	}
-	// 	updateMutex.Lock()
-	// 	update.SolanaMintEvents = append(update.SolanaMintEvents, events...)
-	// 	updateMutex.Unlock()
-	// }()
-
-	// Fetch SolRockBTC Mints
-	// wg.Add(1)
-	// go func() {
-	// 	defer wg.Done()
-	// 	events, err := o.getSolROCKMints(sidecartypes.SolRockProgramID[o.Config.Network])
-	// 	if err != nil {
-	// 		errChan <- fmt.Errorf("failed to process SolROCK mint events: %w", err)
-	// 		return
-	// 	}
-	// 	updateMutex.Lock()
-	// 	update.SolanaMintEvents = append(update.SolanaMintEvents, events...)
-	// 	updateMutex.Unlock()
-	// }()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		events, err := o.getSolROCKMints(sidecartypes.SolRockProgramID[o.Config.Network])
+		if err != nil {
+			errChan <- fmt.Errorf("failed to process SolROCK mint events: %w", err)
+			return
+		}
+		updateMutex.Lock()
+		update.SolanaMintEvents = append(update.SolanaMintEvents, events...)
+		updateMutex.Unlock()
+	}()
 
 	// Fetch SolZenBTC Mints
-	// wg.Add(1)
-	// go func() {
-	// 	defer wg.Done()
-	// 	events, err := o.getSolZenBTCMints(sidecartypes.ZenBTCSolanaProgramID[o.Config.Network])
-	// 	if err != nil {
-	// 		errChan <- fmt.Errorf("failed to process SolZenBTC mint events: %w", err)
-	// 		return
-	// 	}
-	// 	updateMutex.Lock()
-	// 	update.SolanaMintEvents = append(update.SolanaMintEvents, events...)
-	// 	updateMutex.Unlock()
-	// }()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		events, err := o.getSolZenBTCMints(sidecartypes.ZenBTCSolanaProgramID[o.Config.Network])
+		if err != nil {
+			errChan <- fmt.Errorf("failed to process SolZenBTC mint events: %w", err)
+			return
+		}
+		updateMutex.Lock()
+		update.SolanaMintEvents = append(update.SolanaMintEvents, events...)
+		updateMutex.Unlock()
+	}()
 
 	// Fetch Solana burn events
-	// wg.Add(1)
-	// go func() {
-	// 	defer wg.Done()
-	// 	solanaProgramID := sidecartypes.ZenBTCSolanaProgramID[o.Config.Network]
-	// 	events, err := o.getSolanaBurnEvents(solanaProgramID)
-	// 	if err != nil {
-	// 		errChan <- fmt.Errorf("failed to process Solana burn events: %w", err)
-	// 		return
-	// 	}
-	// 	updateMutex.Lock()
-	// 	update.solanaBurnEvents = events
-	// 	updateMutex.Unlock()
-	// }()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		solanaProgramID := sidecartypes.ZenBTCSolanaProgramID[o.Config.Network]
+		events, err := o.getSolanaZenBTCBurnEvents(solanaProgramID)
+		if err != nil {
+			errChan <- fmt.Errorf("failed to process Solana burn events: %w", err)
+			return
+		}
+		updateMutex.Lock()
+		update.solanaBurnEvents = events
+		updateMutex.Unlock()
+	}()
+
+	// Fetch Solana ROCK burn events
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		solanaProgramID := sidecartypes.SolRockProgramID[o.Config.Network]
+		events, err := o.getSolanaRockBurnEvents(solanaProgramID)
+		if err != nil {
+			errChan <- fmt.Errorf("failed to process Solana burn events: %w", err)
+			return
+		}
+		updateMutex.Lock()
+		update.solanaBurnEvents = append(update.solanaBurnEvents, events...)
+		updateMutex.Unlock()
+	}()
 
 	// Wait for all goroutines to complete
 	wg.Wait()
@@ -765,8 +765,8 @@ func (o *Oracle) getSolanaLamportsPerSignature(ctx context.Context) (uint64, err
 	return feeCalculator, nil
 }
 
-// getSolanaBurnEvents retrieves ZenBTC burn events from Solana.
-func (o *Oracle) getSolanaBurnEvents(programID string) ([]api.BurnEvent, error) {
+// getSolanaZenBTCBurnEvents retrieves ZenBTC burn events from Solana.
+func (o *Oracle) getSolanaZenBTCBurnEvents(programID string) ([]api.BurnEvent, error) {
 	limit := sidecartypes.SolanaEventScanTxLimit
 
 	program, err := solana.PublicKeyFromBase58(programID)
@@ -806,6 +806,61 @@ func (o *Oracle) getSolanaBurnEvents(programID string) ([]api.BurnEvent, error) 
 		for logIndex, event := range events {
 			if event.Name == "TokenRedemption" {
 				e := event.Data.(*zenbtc_spl_token.TokenRedemptionEventData)
+
+				burnEvents = append(burnEvents, api.BurnEvent{
+					TxID:            signature.Signature.String(), // Use transaction signature as TxID
+					LogIndex:        uint64(logIndex),             // Use log index within the transaction
+					ChainID:         chainID,
+					DestinationAddr: e.DestAddr[:],
+					Amount:          e.Value,
+				})
+			}
+		}
+	}
+	return burnEvents, nil
+}
+
+// getSolanaRockBurnEvents retrieves ZenBTC burn events from Solana.
+func (o *Oracle) getSolanaRockBurnEvents(programID string) ([]api.BurnEvent, error) {
+	limit := sidecartypes.SolanaEventScanTxLimit
+
+	program, err := solana.PublicKeyFromBase58(programID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to obtain program public key: %w", err)
+	}
+	signatures, err := o.solanaClient.GetSignaturesForAddressWithOpts(context.Background(), program, &solrpc.GetSignaturesForAddressOpts{
+		Limit:      &limit,
+		Commitment: solrpc.CommitmentConfirmed,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Solana ZenBTC burn signatures: %w", err)
+	}
+
+	var burnEvents []api.BurnEvent
+
+	for _, signature := range signatures {
+		tx, err := o.solanaClient.GetTransaction(context.Background(), signature.Signature, &solrpc.GetTransactionOpts{
+			Commitment: solrpc.CommitmentConfirmed,
+		})
+		if err != nil {
+			// Log error and continue to next signature
+			log.Printf("Failed to get Solana ZenBTC burn transaction %s: %v", signature.Signature, err)
+			continue
+		}
+
+		events, err := rock_spl_token.DecodeEvents(tx, program)
+		if err != nil {
+			// Log error and continue to next signature
+			log.Printf("Failed to decode Solana ZenBTC burn events for tx %s: %v", signature.Signature, err)
+			continue
+		}
+
+		// Solana CAIP-2 Identifier
+		chainID := sidecartypes.SolanaCAIP2[o.Config.Network]
+
+		for logIndex, event := range events {
+			if event.Name == "TokenRedemption" {
+				e := event.Data.(*rock_spl_token.TokenRedemptionEventData)
 
 				burnEvents = append(burnEvents, api.BurnEvent{
 					TxID:            signature.Signature.String(), // Use transaction signature as TxID

--- a/sidecar/server.go
+++ b/sidecar/server.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -176,6 +177,9 @@ func (s *oracleService) GetSolanaAccountInfo(ctx context.Context, req *api.Solan
 		},
 	)
 	if err != nil {
+		if errors.Is(err, rpc.ErrNotFound) {
+			return &api.SolanaAccountInfoResponse{}, nil
+		}
 		return nil, fmt.Errorf("failed to get Solana account info: %w", err)
 	}
 	return &api.SolanaAccountInfoResponse{

--- a/x/validation/keeper/abci.go
+++ b/x/validation/keeper/abci.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,7 +15,8 @@ import (
 	"cosmossdk.io/collections"
 	"cosmossdk.io/math"
 	sdkmath "cosmossdk.io/math"
-	sidecarapitypes "github.com/Zenrock-Foundation/zrchain/v6/sidecar/proto/api" // Added import
+	"github.com/Zenrock-Foundation/zrchain/v6/app/params"
+	sidecarapitypes "github.com/Zenrock-Foundation/zrchain/v6/sidecar/proto/api"
 	treasurytypes "github.com/Zenrock-Foundation/zrchain/v6/x/treasury/types"
 	"github.com/Zenrock-Foundation/zrchain/v6/x/validation/types"
 	zentptypes "github.com/Zenrock-Foundation/zrchain/v6/x/zentp/types"
@@ -142,6 +144,7 @@ func (k *Keeper) constructVoteExtension(ctx context.Context, height int64, oracl
 	if err != nil {
 		return VoteExtension{}, err
 	}
+	solanaMintEventsHash, err := deriveHash(oracleData.SolanaMintEvents)
 
 	solAccs, err := k.collectSolanaAccounts(ctx)
 	if err != nil {
@@ -180,8 +183,8 @@ func (k *Keeper) constructVoteExtension(ctx context.Context, height int64, oracl
 		RequestedCompleterNonce:    nonces[k.zenBTCKeeper.GetCompleterKeyID(ctx)],
 		SolanaMintNonceHashes:      solNonceHash[:],
 		SolanaAccountsHash:         solAccsHash[:],
-		//SolanaMintEventsHash:       solanaBurnEventsHash[:],
-		SolanaBurnEventsHash: solanaBurnEventsHash[:],
+		SolanaMintEventsHash:       solanaMintEventsHash[:],
+		SolanaBurnEventsHash:       solanaBurnEventsHash[:],
 	}
 
 	return voteExt, nil
@@ -350,23 +353,23 @@ func (k *Keeper) PreBlocker(ctx sdk.Context, req *abci.RequestFinalizeBlock) err
 		if fieldHasConsensus(oracleData.FieldVotePowers, VEFieldEthBurnEventsHash) {
 			k.storeNewZenBTCBurnEventsEthereum(ctx, oracleData)
 		}
-		// if fieldHasConsensus(oracleData.FieldVotePowers, VEFieldSolanaBurnEventsHash) {
-		// 	k.storeNewZenBTCBurnEventsSolana(ctx, oracleData)
-		// }
+		if fieldHasConsensus(oracleData.FieldVotePowers, VEFieldSolanaBurnEventsHash) {
+			k.storeNewZenBTCBurnEventsSolana(ctx, oracleData)
+		}
 		if fieldHasConsensus(oracleData.FieldVotePowers, VEFieldRedemptionsHash) {
 			k.storeNewZenBTCRedemptions(ctx, oracleData)
 		}
 
 		k.processZenBTCStaking(ctx, oracleData)
 		k.processZenBTCMintsEthereum(ctx, oracleData)
-		// k.processZenBTCMintsSolana(ctx, oracleData)
+		k.processZenBTCMintsSolana(ctx, oracleData)
 		k.processZenBTCBurnEvents(ctx, oracleData)
 		k.processZenBTCRedemptions(ctx, oracleData)
 		k.checkForRedemptionFulfilment(ctx)
-		// k.processSolanaZenBTCMintEvents(ctx, oracleData)
-		// k.processSolanaROCKMints(ctx, oracleData)
-		// k.processSolanaROCKMintEvents(ctx, oracleData)
-		// k.clearSolanaAccounts(ctx)
+		k.processSolanaZenBTCMintEvents(ctx, oracleData)
+		k.processSolanaROCKMints(ctx, oracleData)
+		k.processSolanaROCKMintEvents(ctx, oracleData)
+		k.clearSolanaAccounts(ctx)
 	}
 
 	k.recordNonVotingValidators(ctx, req)
@@ -1322,16 +1325,14 @@ func (k *Keeper) processSolanaROCKMints(ctx sdk.Context, oracleData OracleData) 
 		nil,
 		oracleData.SolanaMintNonces[k.zentpKeeper.GetSolanaParams(ctx).NonceAccountKey],
 		func(ctx sdk.Context) ([]*zentptypes.Bridge, error) {
-			return k.zentpKeeper.GetMintsWithStatus(ctx, zentptypes.BridgeStatus_BRIDGE_STATUS_PENDING)
+			mints, err := k.zentpKeeper.GetMintsWithStatus(ctx, zentptypes.BridgeStatus_BRIDGE_STATUS_PENDING)
+			return mints, err
 		},
 		func(tx *zentptypes.Bridge) error {
-			// Check for pending tx, if there are some - wait until they are completed, so that we can use the durable nonce
-			pendings, err := k.zentpKeeper.GetMintsWithStatus(ctx, zentptypes.BridgeStatus_BRIDGE_STATUS_PENDING)
-			if err != nil {
-				return fmt.Errorf("cannot get pending mints: %w", err)
-			}
-			if len(pendings) > 0 {
-				return fmt.Errorf("waiting for pending mint to complete")
+			// Check whether this tx has already been processed, if it has been - we wait for it to complete (or timeout)
+			if tx.BlockHeight > 0 {
+				k.Logger(ctx).Info("waiting for pending zentp solana mint tx", "tx_id", tx.Id, "block_height", tx.BlockHeight)
+				return nil
 			}
 
 			// Check for consensus
@@ -1450,6 +1451,7 @@ func (k *Keeper) processSolanaROCKMintEvents(ctx sdk.Context, oracleData OracleD
 			childReq, err := k.treasuryKeeper.SignRequestStore.Get(ctx, id)
 			if err != nil {
 				k.Logger(ctx).Error("SignRequestStore.Get: ", err.Error())
+				return
 			}
 			if len(childReq.SignedData) != 1 {
 				continue
@@ -1477,34 +1479,37 @@ func (k *Keeper) processSolanaROCKMintEvents(ctx sdk.Context, oracleData OracleD
 
 // processROCKBurns processes pending mint transactions.
 func (k *Keeper) processSolanaZenBTCMintEvents(ctx sdk.Context, oracleData OracleData) {
-	k.Logger(ctx).Info("processSolanaZenBTCMintEvents, events#: %d", len(oracleData.SolanaMintEvents))
+	k.Logger(ctx).Warn("starting processSolanaZenBTCMintEvents", "event_count", len(oracleData.SolanaMintEvents))
 	id, err := k.zenBTCKeeper.GetFirstPendingSolMintTransaction(ctx)
 	if err != nil {
 		if errors.Is(err, collections.ErrNotFound) {
+			k.Logger(ctx).Warn("processSolanaZenBTCMintEvents: no pending Solana mint transactions found")
 			return
 		}
-		k.Logger(ctx).Error("GetFirstPendingSolMintTransaction: ", err.Error())
+		k.Logger(ctx).Error("processSolanaZenBTCMintEvents: error getting first pending Solana mint transaction", "error", err)
 		return
 	}
-	k.Logger(ctx).Info("GetFirstPendingSolMintTransaction: ", id)
+	k.Logger(ctx).Warn("processSolanaZenBTCMintEvents: first pending Solana mint transaction", "id", id)
 	if id == 0 {
+		k.Logger(ctx).Warn("processSolanaZenBTCMintEvents: no pending Solana mint transactions found")
 		return
 	}
 	pendingMint, err := k.zenBTCKeeper.GetPendingMintTransactionsStore().Get(ctx, id)
 	if err != nil {
-		k.Logger(ctx).Error("GetPendingMintTransactionsStore.Get: ", err.Error())
+		k.Logger(ctx).Error("processSolanaZenBTCMintEvents: error getting pending mint transaction", "id", id, "error", err)
 		return
 	}
 
 	tx, err := k.treasuryKeeper.SignTransactionRequestStore.Get(ctx, id)
 	if err != nil {
-		k.Logger(ctx).Error("SignTransactionRequestStore.Get: ", err.Error())
+		k.Logger(ctx).Error("processSolanaZenBTCMintEvents: error getting sign transaction request", "id", id, "error", err)
 		return
 	}
 
 	sigReq, err := k.treasuryKeeper.SignRequestStore.Get(ctx, tx.SignRequestId)
 	if err != nil {
-		k.Logger(ctx).Error("SignRequestStore.Get: ", err.Error())
+		k.Logger(ctx).Error("processSolanaZenBTCMintEvents: error getting sign request", "id", tx.SignRequestId, "error", err)
+		return
 	}
 
 	var (
@@ -1515,7 +1520,7 @@ func (k *Keeper) processSolanaZenBTCMintEvents(ctx sdk.Context, oracleData Oracl
 	for _, id := range sigReq.ChildReqIds {
 		childReq, err := k.treasuryKeeper.SignRequestStore.Get(ctx, id)
 		if err != nil {
-			k.Logger(ctx).Error("SignRequestStore.Get: ", err.Error())
+			k.Logger(ctx).Error("processSolanaZenBTCMintEvents: error getting child sign request", "id", id, "error", err)
 		}
 		if len(childReq.SignedData) != 1 {
 			continue
@@ -1527,29 +1532,29 @@ func (k *Keeper) processSolanaZenBTCMintEvents(ctx sdk.Context, oracleData Oracl
 		if bytes.Equal(event.SigHash, sigHash[:]) {
 			supply, err := k.zenBTCKeeper.GetSupply(ctx)
 			if err != nil {
-				k.Logger(ctx).Error("zenBTCKeeper.GetSupply: ", err.Error())
+				k.Logger(ctx).Error("processSolanaZenBTCMintEvents: error getting zenBTC supply", "error", err)
 				return
 			}
 			supply.PendingZenBTC -= pendingMint.Amount
 			supply.MintedZenBTC += pendingMint.Amount
 			if err := k.zenBTCKeeper.SetSupply(ctx, supply); err != nil {
-				k.Logger(ctx).Error("zenBTCKeeper.SetSupply: ", err.Error())
+				k.Logger(ctx).Error("processSolanaZenBTCMintEvents: error setting zenBTC supply", "error", err)
 				return
 			}
-			k.Logger(ctx).Warn("pending mint supply updated",
+			k.Logger(ctx).Warn("processSolanaZenBTCMintEvents: pending mint supply updated",
 				"pending_mint_old", supply.PendingZenBTC+pendingMint.Amount,
 				"pending_mint_new", supply.PendingZenBTC,
 			)
-			k.Logger(ctx).Warn("minted supply updated",
+			k.Logger(ctx).Warn("processSolanaZenBTCMintEvents: minted supply updated",
 				"minted_old", supply.MintedZenBTC-pendingMint.Amount,
 				"minted_new", supply.MintedZenBTC,
 			)
 			pendingMint.Status = zenbtctypes.MintTransactionStatus_MINT_TRANSACTION_STATUS_MINTED
 			if err = k.zenBTCKeeper.SetPendingMintTransaction(ctx, pendingMint); err != nil {
-				k.Logger(ctx).Error("zenBTCKeeper.SetPendingMintTransaction: ", err.Error())
+				k.Logger(ctx).Error("processSolanaZenBTCMintEvents: error setting pending mint transaction", "error", err)
 			}
 			if err = k.zenBTCKeeper.SetFirstPendingSolMintTransaction(ctx, 0); err != nil {
-				k.Logger(ctx).Error("zenBTCKeeper.SetFirstPendingSolMintTransaction: ", err.Error())
+				k.Logger(ctx).Error("processSolanaZenBTCMintEvents: error setting first pending Solana mint transaction", "error", err)
 			}
 		}
 	}
@@ -1567,26 +1572,31 @@ func (k *Keeper) storeNewZenBTCBurnEventsSolana(ctx sdk.Context, oracleData Orac
 
 // storeNewZenBTCBurnEvents is a helper function to store new burn events from a given source.
 func (k *Keeper) storeNewZenBTCBurnEvents(ctx sdk.Context, burnEvents []sidecarapitypes.BurnEvent, source string, nonceErrorMsg string) {
+	k.Logger(ctx).Warn("starting storeNewZenBTCBurnEvents", "source", source, "event_count", len(burnEvents))
 	foundNewBurn := false
 	// Loop over each burn event from oracle to check for new ones.
-	for _, burn := range burnEvents {
+	for i, burn := range burnEvents {
+		k.Logger(ctx).Warn("storeNewZenBTCBurnEvents: processing event", "index", i, "source", source, "tx_id", burn.TxID, "log_index", burn.LogIndex, "chain_id", burn.ChainID, "amount", burn.Amount)
 		// Check if this burn event already exists
 		exists := false
-		if err := k.zenBTCKeeper.WalkBurnEvents(ctx, func(id uint64, existingBurn zenbtctypes.BurnEvent) (bool, error) {
+		walkErr := k.zenBTCKeeper.WalkBurnEvents(ctx, func(id uint64, existingBurn zenbtctypes.BurnEvent) (bool, error) {
 			// Compare fields from the input burn event data with the stored BurnEvent
 			if existingBurn.TxID == burn.TxID &&
 				existingBurn.LogIndex == burn.LogIndex &&
 				existingBurn.ChainID == burn.ChainID {
+				k.Logger(ctx).Warn("storeNewZenBTCBurnEvents: event already exists", "index", i, "source", source, "tx_id", burn.TxID, "log_index", burn.LogIndex, "chain_id", burn.ChainID, "existing_id", id)
 				exists = true
-				return true, nil
+				return true, nil // Stop walking
 			}
-			return false, nil
-		}); err != nil {
-			k.Logger(ctx).Error("error walking burn events", "source", source, "error", err)
-			continue
+			return false, nil // Continue walking
+		})
+		if walkErr != nil {
+			k.Logger(ctx).Warn("storeNewZenBTCBurnEvents: error walking burn events", "index", i, "source", source, "error", walkErr)
+			continue // Process next event
 		}
 
 		if !exists {
+			k.Logger(ctx).Warn("storeNewZenBTCBurnEvents: event does not exist, creating new", "index", i, "source", source, "tx_id", burn.TxID, "log_index", burn.LogIndex, "chain_id", burn.ChainID)
 			// Create a new BurnEvent using data from the input struct
 			newBurn := zenbtctypes.BurnEvent{
 				TxID:            burn.TxID,
@@ -1596,22 +1606,28 @@ func (k *Keeper) storeNewZenBTCBurnEvents(ctx sdk.Context, burnEvents []sidecara
 				Amount:          burn.Amount,
 				Status:          zenbtctypes.BurnStatus_BURN_STATUS_BURNED,
 			}
-			id, err := k.zenBTCKeeper.CreateBurnEvent(ctx, &newBurn)
-			if err != nil {
-				k.Logger(ctx).Error("error creating burn event", "source", source, "error", err)
-				continue
+			createdID, createErr := k.zenBTCKeeper.CreateBurnEvent(ctx, &newBurn)
+			if createErr != nil {
+				k.Logger(ctx).Warn("storeNewZenBTCBurnEvents: error creating burn event", "index", i, "source", source, "tx_id", burn.TxID, "error", createErr)
+				continue // Process next event
 			}
-			k.Logger(ctx).Info(fmt.Sprintf("created new %s burn event", source), "id", id)
+			k.Logger(ctx).Warn("storeNewZenBTCBurnEvents: created new burn event", "index", i, "source", source, "new_id", createdID, "tx_id", burn.TxID, "log_index", burn.LogIndex)
 			foundNewBurn = true
+		} else {
+			k.Logger(ctx).Warn("storeNewZenBTCBurnEvents: skipping existing event", "index", i, "source", source, "tx_id", burn.TxID, "log_index", burn.LogIndex)
 		}
 	}
 
 	// If a new burn event is found, we need to request the unstaker's Ethereum nonce
 	// because the unstaking transaction happens on Ethereum, regardless of the burn source.
 	if foundNewBurn {
-		if err := k.EthereumNonceRequested.Set(ctx, k.zenBTCKeeper.GetUnstakerKeyID(ctx), true); err != nil {
-			k.Logger(ctx).Error(nonceErrorMsg, "error", err)
+		unstakerKeyID := k.zenBTCKeeper.GetUnstakerKeyID(ctx)
+		k.Logger(ctx).Warn("storeNewZenBTCBurnEvents: found new burn events, setting EthereumNonceRequested for unstaker", "source", source, "unstaker_key_id", unstakerKeyID)
+		if err := k.EthereumNonceRequested.Set(ctx, unstakerKeyID, true); err != nil {
+			k.Logger(ctx).Warn(fmt.Sprintf("storeNewZenBTCBurnEvents: %s", nonceErrorMsg), "source", source, "error", err)
 		}
+	} else {
+		k.Logger(ctx).Warn("storeNewZenBTCBurnEvents: no new burn events found", "source", source)
 	}
 }
 
@@ -1917,4 +1933,89 @@ func (k *Keeper) checkForRedemptionFulfilment(ctx sdk.Context) {
 		k.Logger(ctx).Error("error updating zenBTC supply", "error", err)
 	}
 
+}
+
+func (k Keeper) processSolanaROCKBurnEvents(ctx sdk.Context, oracleData OracleData) {
+	k.Logger(ctx).Warn("starting processSolanaROCKBurnEvents", "event_count", len(oracleData.SolanaBurnEvents))
+	var toProcess []*sidecarapitypes.BurnEvent
+	for i, e := range oracleData.SolanaBurnEvents {
+		k.Logger(ctx).Warn("processSolanaROCKBurnEvents: processing event", "index", i, "tx_id", e.TxID, "chain_id", e.ChainID, "amount", e.Amount, "destination_bytes", hex.EncodeToString(e.DestinationAddr))
+
+		// Try to parse destination address assuming it's the first 20 bytes for EVM-like addresses on Solana?
+		if len(e.DestinationAddr) < 20 {
+			k.Logger(ctx).Warn("processSolanaROCKBurnEvents: destination address too short", "index", i, "tx_id", e.TxID, "len", len(e.DestinationAddr))
+			continue
+		}
+		destBytes := e.DestinationAddr[:20]
+		addr, err := sdk.Bech32ifyAddressBytes("zen", destBytes)
+		if err != nil {
+			k.Logger(ctx).Warn("processSolanaROCKBurnEvents: failed to Bech32ify destination address", "index", i, "tx_id", e.TxID, "dest_bytes", hex.EncodeToString(destBytes), "error", err)
+			continue
+		}
+		k.Logger(ctx).Warn("processSolanaROCKBurnEvents: checking for existing burn record", "index", i, "tx_id", e.TxID, "chain_id", e.ChainID, "recipient_bech32", addr)
+		burns, err := k.zentpKeeper.GetBurns(ctx, addr, e.ChainID, e.TxID)
+		if err != nil {
+			k.Logger(ctx).Warn("processSolanaROCKBurnEvents: error checking for existing burn record", "index", i, "tx_id", e.TxID, "error", err)
+			continue
+		}
+		if len(burns) > 0 {
+			k.Logger(ctx).Warn("processSolanaROCKBurnEvents: burn already processed, skipping", "index", i, "tx_id", e.TxID, "existing_burn_count", len(burns))
+			continue // burn already processed
+		} else {
+			k.Logger(ctx).Warn("processSolanaROCKBurnEvents: burn not yet processed, adding to list", "index", i, "tx_id", e.TxID)
+			toProcess = append(toProcess, &e)
+		}
+	}
+
+	k.Logger(ctx).Warn("processSolanaROCKBurnEvents: finished filtering events", "to_process_count", len(toProcess))
+
+	// TODO do cleanup on error. e.g. burn minted funds if there is an error sendig them to the recipient, or adding of the bridge fails
+	for i, burn := range toProcess {
+		k.Logger(ctx).Warn("processSolanaROCKBurnEvents: processing new burn", "index", i, "tx_id", burn.TxID, "amount", burn.Amount)
+		coins := sdk.NewCoins(sdk.NewCoin(params.BondDenom, math.NewIntFromUint64(burn.Amount)))
+		k.Logger(ctx).Warn("processSolanaROCKBurnEvents: minting coins", "index", i, "tx_id", burn.TxID, "module", zentptypes.ModuleName, "coins", coins.String())
+		if err := k.bankKeeper.MintCoins(ctx, zentptypes.ModuleName, coins); err != nil {
+			k.Logger(ctx).Warn("processSolanaROCKBurnEvents: failed to mint coins", "index", i, "tx_id", burn.TxID, "error", err)
+			continue
+		}
+
+		// Re-derive bech32 address for sending
+		if len(burn.DestinationAddr) < 20 {
+			k.Logger(ctx).Warn("processSolanaROCKBurnEvents: destination address too short for sending", "index", i, "tx_id", burn.TxID)
+			continue // Should have been caught earlier, but double-check
+		}
+		destBytes := burn.DestinationAddr[:20]
+		addr, err := sdk.Bech32ifyAddressBytes("zen", destBytes)
+		if err != nil {
+			k.Logger(ctx).Warn("processSolanaROCKBurnEvents: failed to Bech32ify destination address for sending", "index", i, "tx_id", burn.TxID, "error", err)
+			continue
+		}
+		accAddr, err := sdk.AccAddressFromBech32(addr)
+		if err != nil {
+			k.Logger(ctx).Warn("processSolanaROCKBurnEvents: failed to convert Bech32 to AccAddress", "index", i, "tx_id", burn.TxID, "bech32_addr", addr, "error", err)
+			continue
+		}
+		k.Logger(ctx).Warn("processSolanaROCKBurnEvents: sending coins to recipient", "index", i, "tx_id", burn.TxID, "recipient", accAddr.String(), "coins", coins.String())
+		if err = k.bankKeeper.SendCoinsFromModuleToAccount(ctx, zentptypes.ModuleName, accAddr, coins); err != nil {
+			k.Logger(ctx).Warn("processSolanaROCKBurnEvents: failed to send coins", "index", i, "tx_id", burn.TxID, "recipient", accAddr.String(), "error", err)
+			// TODO: What should happen here? Burn the minted coins? Retry later?
+			continue // Continue to adding burn record for now
+		}
+
+		bridgeRecord := &zentptypes.Bridge{
+			Denom:            params.BondDenom,
+			Amount:           burn.Amount,
+			RecipientAddress: accAddr.String(),
+			SourceChain:      burn.ChainID,
+			TxHash:           burn.TxID,
+			State:            zentptypes.BridgeStatus_BRIDGE_STATUS_COMPLETED,
+			BlockHeight:      ctx.BlockHeight(),
+		}
+		k.Logger(ctx).Warn("processSolanaROCKBurnEvents: adding burn record", "index", i, "tx_id", burn.TxID, "record", fmt.Sprintf("%+v", bridgeRecord))
+		err = k.zentpKeeper.AddBurn(ctx, bridgeRecord)
+		if err != nil {
+			k.Logger(ctx).Warn("processSolanaROCKBurnEvents: failed to add burn record", "index", i, "tx_id", burn.TxID, "error", err)
+		}
+	}
+	k.Logger(ctx).Warn("finished processSolanaROCKBurnEvents")
 }

--- a/x/validation/keeper/abci_types.go
+++ b/x/validation/keeper/abci_types.go
@@ -49,11 +49,10 @@ type (
 		RequestedCompleterNonce    uint64
 		SolanaMintNonceHashes      []byte
 		SolanaAccountsHash         []byte
-		SolanaROCKMintEventsHash   []byte
-		SolanaZenBTCMintEventsHash []byte
 		SolanaLamportsPerSignature uint64
 		EthBurnEventsHash          []byte
 		SolanaBurnEventsHash       []byte
+		SolanaMintEventsHash       []byte
 		RedemptionsHash            []byte
 		ROCKUSDPrice               string
 		BTCUSDPrice                string
@@ -281,8 +280,7 @@ const (
 	VEFieldLatestBtcHeaderHash
 	VEFieldSolanaMintNoncesHash
 	VEFieldSolanaAccountsHash
-	VEFieldSolanaROCKMintEventsHash
-	VEFieldSolanaZenBTCMintEventsHash
+	VEFieldSolanaMintEventsHash
 )
 
 // FieldHandler defines operations for processing a specific vote extension field
@@ -365,8 +363,8 @@ func (f VoteExtensionField) String() string {
 		return "SolanaMintNoncesHash"
 	case VEFieldSolanaAccountsHash:
 		return "SolanaAccountsHash"
-	case VEFieldSolanaROCKMintEventsHash:
-		return "SolanaROCKMintEventsHash"
+	case VEFieldSolanaMintEventsHash:
+		return "SolanaMintEventsHash"
 	default:
 		return "Unknown"
 	}
@@ -417,9 +415,9 @@ func initializeFieldHandlers() []FieldHandler {
 			SetValue: func(v any, ve *VoteExtension) { ve.SolanaAccountsHash = v.([]byte) },
 		},
 		{
-			Field:    VEFieldSolanaROCKMintEventsHash,
-			GetValue: func(ve VoteExtension) any { return ve.SolanaROCKMintEventsHash },
-			SetValue: func(v any, ve *VoteExtension) { ve.SolanaROCKMintEventsHash = v.([]byte) },
+			Field:    VEFieldSolanaMintEventsHash,
+			GetValue: func(ve VoteExtension) any { return ve.SolanaMintEventsHash },
+			SetValue: func(v any, ve *VoteExtension) { ve.SolanaMintEventsHash = v.([]byte) },
 		},
 
 		// Integer fields

--- a/x/validation/keeper/abci_utils.go
+++ b/x/validation/keeper/abci_utils.go
@@ -125,7 +125,7 @@ func (k Keeper) GetSuperMajorityVEData(ctx context.Context, currentHeight int64,
 	fieldVotes := make(map[VoteExtensionField]map[string]fieldVote)
 
 	// Initialize maps for each field type
-	for i := VEFieldZRChainBlockHeight; i <= VEFieldSolanaROCKMintEventsHash; i++ {
+	for i := VEFieldZRChainBlockHeight; i <= VEFieldSolanaMintEventsHash; i++ {
 		fieldVotes[i] = make(map[string]fieldVote)
 	}
 
@@ -259,7 +259,7 @@ func (k Keeper) logConsensusResults(ctx context.Context, fieldVotePowers map[Vot
 	fieldsWithConsensus := make([]string, 0)
 	fieldsWithoutConsensus := make([]string, 0)
 
-	for field := VEFieldZRChainBlockHeight; field <= VEFieldSolanaROCKMintEventsHash; field++ {
+	for field := VEFieldZRChainBlockHeight; field <= VEFieldSolanaMintEventsHash; field++ {
 		// Skip logging the ZRChainBlockHeight field
 		if field == VEFieldZRChainBlockHeight {
 			continue
@@ -1280,61 +1280,94 @@ func (k *Keeper) submitSolanaTransaction(ctx sdk.Context, creator string, keyIDs
 
 func (k Keeper) GetSolanaNonceAccount(goCtx context.Context, keyID uint64) (system.NonceAccount, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+	k.Logger(ctx).Warn("starting GetSolanaNonceAccount", "keyID", keyID)
 	key, err := k.treasuryKeeper.GetKey(ctx, keyID)
 	if err != nil {
+		k.Logger(ctx).Warn("GetSolanaNonceAccount: failed to get key", "keyID", keyID, "error", err)
 		return system.NonceAccount{}, err
 	}
 	publicKey, err := treasurytypes.SolanaPubkey(key)
 	if err != nil {
+		k.Logger(ctx).Warn("GetSolanaNonceAccount: failed to derive pubkey", "keyID", keyID, "error", err)
 		return system.NonceAccount{}, err
 	}
+	k.Logger(ctx).Warn("GetSolanaNonceAccount: derived pubkey", "keyID", keyID, "pubkey", publicKey.String())
 	resp, err := k.sidecarClient.GetSolanaAccountInfo(goCtx, &sidecar.SolanaAccountInfoRequest{
 		PubKey: publicKey.String(),
 	})
 	if err != nil {
-		k.Logger(ctx).Error("failed to get solana account info from sidecar: ", err)
+		k.Logger(ctx).Warn("GetSolanaNonceAccount: failed to get solana account info from sidecar", "keyID", keyID, "pubkey", publicKey.String(), "error", err)
 		return system.NonceAccount{}, err
 	}
+	k.Logger(ctx).Warn("GetSolanaNonceAccount: received account info from sidecar", "keyID", keyID, "pubkey", publicKey.String(), "account_data_len", len(resp.Account))
+
 	nonceAccount := system.NonceAccount{}
 	decoder := bin.NewBorshDecoder(resp.Account)
 
+	k.Logger(ctx).Warn("GetSolanaNonceAccount: decoding nonce account data", "keyID", keyID, "pubkey", publicKey.String())
 	if err = nonceAccount.UnmarshalWithDecoder(decoder); err != nil {
-		return nonceAccount, err
+		k.Logger(ctx).Warn("GetSolanaNonceAccount: failed to decode nonce account data", "keyID", keyID, "pubkey", publicKey.String(), "error", err)
+		return nonceAccount, err // Return partially decoded account potentially? Or empty? Returning with error.
 	}
-	return nonceAccount, err
+	k.Logger(ctx).Warn("finished GetSolanaNonceAccount successfully", "keyID", keyID, "pubkey", publicKey.String(), "nonce_value", nonceAccount.Nonce.String())
+	return nonceAccount, nil // Changed the last err return to nil as per original logic if Unmarshal succeeded
 }
 
 func (k Keeper) GetSolanaTokenAccount(goCtx context.Context, address, mint string) (token.Account, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	k.Logger(ctx).Warn("starting GetSolanaTokenAccount", "address", address, "mint", mint)
 	recipientPubKey, err := solana.PublicKeyFromBase58(address)
 	if err != nil {
+		k.Logger(ctx).Warn("GetSolanaTokenAccount: invalid recipient address", "address", address, "error", err)
 		return token.Account{}, err
 	}
 	mintPubKey, err := solana.PublicKeyFromBase58(mint)
 	if err != nil {
+		k.Logger(ctx).Warn("GetSolanaTokenAccount: invalid mint address", "mint", mint, "error", err)
 		return token.Account{}, err
 	}
+	k.Logger(ctx).Warn("GetSolanaTokenAccount: finding ATA", "recipient", recipientPubKey.String(), "mint", mintPubKey.String())
 	receiverAta, _, err := solana.FindAssociatedTokenAddress(recipientPubKey, mintPubKey)
 	if err != nil {
+		k.Logger(ctx).Warn("GetSolanaTokenAccount: failed to find ATA", "recipient", recipientPubKey.String(), "mint", mintPubKey.String(), "error", err)
 		return token.Account{}, err
 	}
+	k.Logger(ctx).Warn("GetSolanaTokenAccount: found ATA", "ata", receiverAta.String())
+
+	k.Logger(ctx).Warn("GetSolanaTokenAccount: getting account info from sidecar", "ata", receiverAta.String())
 	resp, err := k.sidecarClient.GetSolanaAccountInfo(goCtx, &sidecar.SolanaAccountInfoRequest{
 		PubKey: receiverAta.String(),
 	})
 	if err != nil {
-		if err.Error() == "rpc error: code = Unknown desc = not found" {
-			return token.Account{}, nil
+		// Check for specific "not found" error from sidecar
+		if strings.Contains(err.Error(), "not found") { // More robust check than exact string match
+			k.Logger(ctx).Warn("GetSolanaTokenAccount: ATA not found on chain (likely needs creation)", "ata", receiverAta.String())
+			// Return an empty account with Uninitialized state, as expected by callers checking the state.
+			return token.Account{State: solToken.Uninitialized}, nil
 		}
+		k.Logger(ctx).Warn("GetSolanaTokenAccount: failed to get account info from sidecar", "ata", receiverAta.String(), "error", err)
 		return token.Account{}, err
 	}
+	k.Logger(ctx).Warn("GetSolanaTokenAccount: received account info from sidecar", "ata", receiverAta.String(), "account_data_len", len(resp.Account))
 
 	tokenAccount := new(token.Account)
+
+	if resp.Account == nil {
+		k.Logger(ctx).Warn("GetSolanaTokenAccount: received nil account data from sidecar", "ata", receiverAta.String())
+		// Treat as uninitialized if data is nil
+		tokenAccount.State = solToken.Uninitialized
+		return *tokenAccount, nil
+	}
+	k.Logger(ctx).Warn("GetSolanaTokenAccount: decoding token account data", "ata", receiverAta.String())
 	decoder := bin.NewBorshDecoder(resp.Account)
 
 	err = tokenAccount.UnmarshalWithDecoder(decoder)
 	if err != nil {
+		k.Logger(ctx).Warn("GetSolanaTokenAccount: failed to decode token account data", "ata", receiverAta.String(), "error", err)
 		return token.Account{}, err
 	}
 
+	k.Logger(ctx).Warn("finished GetSolanaTokenAccount successfully", "ata", receiverAta.String(), "state", int(tokenAccount.State), "amount", tokenAccount.Amount)
 	return *tokenAccount, nil
 }
 
@@ -1357,73 +1390,101 @@ type solanaMintTxRequest struct {
 func (k Keeper) PrepareSolanaMintTx(goCtx context.Context, req *solanaMintTxRequest) ([]byte, error) {
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
+	k.Logger(ctx).Warn("starting PrepareSolanaMintTx", "request", fmt.Sprintf("%+v", req))
+
+	k.Logger(ctx).Warn("PrepareSolanaMintTx: deriving keys and addresses")
 	programID, err := solana.PublicKeyFromBase58(req.programID)
 	if err != nil {
+		k.Logger(ctx).Warn("PrepareSolanaMintTx: invalid programID", "programID", req.programID, "error", err)
 		return nil, err
 	}
 
 	nonceAccKey, err := k.treasuryKeeper.GetKey(ctx, req.nonceAccountKey)
 	if err != nil {
+		k.Logger(ctx).Warn("PrepareSolanaMintTx: failed to get nonce account key", "keyID", req.nonceAccountKey, "error", err)
 		return nil, err
 	}
 
 	nonceAccPubKey, err := treasurytypes.SolanaPubkey(nonceAccKey)
 	if err != nil {
+		k.Logger(ctx).Warn("PrepareSolanaMintTx: failed to derive nonce account pubkey", "keyID", req.nonceAccountKey, "error", err)
 		return nil, err
 	}
 
 	nonceAuthKey, err := k.treasuryKeeper.GetKey(ctx, req.nonceAuthorityKey)
 	if err != nil {
+		k.Logger(ctx).Warn("PrepareSolanaMintTx: failed to get nonce authority key", "keyID", req.nonceAuthorityKey, "error", err)
 		return nil, err
 	}
 	nonceAuthPubKey, err := treasurytypes.SolanaPubkey(nonceAuthKey)
 	if err != nil {
+		k.Logger(ctx).Warn("PrepareSolanaMintTx: failed to derive nonce authority pubkey", "keyID", req.nonceAuthorityKey, "error", err)
 		return nil, err
 	}
 
 	signerKey, err := k.treasuryKeeper.GetKey(ctx, req.signerKey)
 	if err != nil {
+		k.Logger(ctx).Warn("PrepareSolanaMintTx: failed to get signer key", "keyID", req.signerKey, "error", err)
 		return nil, err
 	}
 	signerPubKey, err := treasurytypes.SolanaPubkey(signerKey)
 	if err != nil {
+		k.Logger(ctx).Warn("PrepareSolanaMintTx: failed to derive signer pubkey", "keyID", req.signerKey, "error", err)
 		return nil, err
 	}
 
 	mintKey, err := solana.PublicKeyFromBase58(req.mintAddress)
 	if err != nil {
+		k.Logger(ctx).Warn("PrepareSolanaMintTx: invalid mint address", "mintAddress", req.mintAddress, "error", err)
 		return nil, err
 	}
 
 	feeKey, err := solana.PublicKeyFromBase58(req.feeWallet)
 	if err != nil {
+		k.Logger(ctx).Warn("PrepareSolanaMintTx: invalid fee wallet address", "feeWallet", req.feeWallet, "error", err)
 		return nil, err
 	}
 
 	recipientPubKey, err := solana.PublicKeyFromBase58(req.recipient)
 	if err != nil {
+		k.Logger(ctx).Warn("PrepareSolanaMintTx: invalid recipient address", "recipient", req.recipient, "error", err)
 		return nil, err
 	}
+	k.Logger(ctx).Warn("PrepareSolanaMintTx: derived keys",
+		"programID", programID.String(),
+		"nonceAccPubKey", nonceAccPubKey.String(),
+		"nonceAuthPubKey", nonceAuthPubKey.String(),
+		"signerPubKey", signerPubKey.String(),
+		"mintKey", mintKey.String(),
+		"feeKey", feeKey.String(),
+		"recipientPubKey", recipientPubKey.String(),
+	)
 
 	var instructions []solana.Instruction
 
+	k.Logger(ctx).Warn("PrepareSolanaMintTx: adding AdvanceNonceAccount instruction")
 	instructions = append(instructions, system.NewAdvanceNonceAccountInstruction(
 		*nonceAccPubKey,
 		solana.SysVarRecentBlockHashesPubkey,
 		*nonceAuthPubKey,
 	).Build())
 
+	k.Logger(ctx).Warn("PrepareSolanaMintTx: finding ATAs")
 	feeWalletAta, _, err := solana.FindAssociatedTokenAddress(feeKey, mintKey)
 	if err != nil {
+		k.Logger(ctx).Warn("PrepareSolanaMintTx: failed to find fee wallet ATA", "feeKey", feeKey.String(), "mintKey", mintKey.String(), "error", err)
 		return nil, err
 	}
 
 	receiverAta, _, err := solana.FindAssociatedTokenAddress(recipientPubKey, mintKey)
 	if err != nil {
+		k.Logger(ctx).Warn("PrepareSolanaMintTx: failed to find receiver ATA", "recipientPubKey", recipientPubKey.String(), "mintKey", mintKey.String(), "error", err)
 		return nil, err
 	}
+	k.Logger(ctx).Warn("PrepareSolanaMintTx: found ATAs", "feeWalletAta", feeWalletAta.String(), "receiverAta", receiverAta.String())
 
 	if req.fundReceiver {
+		k.Logger(ctx).Warn("PrepareSolanaMintTx: adding Create AssociatedTokenAccount instruction for receiver", "receiver", recipientPubKey.String())
 		instructions = append(
 			instructions,
 			ata.NewCreateInstruction(
@@ -1435,6 +1496,7 @@ func (k Keeper) PrepareSolanaMintTx(goCtx context.Context, req *solanaMintTxRequ
 	}
 
 	if req.rock {
+		k.Logger(ctx).Warn("PrepareSolanaMintTx: adding solrock Wrap instruction", "amount", req.amount, "fee", req.fee)
 		instructions = append(instructions, solrock.Wrap(
 			programID,
 			rock_spl_token.WrapArgs{
@@ -1485,109 +1547,148 @@ func (k Keeper) PrepareSolanaMintTx(goCtx context.Context, req *solanaMintTxRequ
 }
 
 func (k Keeper) collectSolanaNonces(goCtx context.Context) (map[uint64]*system.NonceAccount, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	k.Logger(ctx).Warn("starting collectSolanaNonces")
 	nonces := map[uint64]*system.NonceAccount{}
-	//pendingSolROCKMints, err := k.zentpKeeper.GetMintsWithStatus(goCtx, zentptypes.BridgeStatus_BRIDGE_STATUS_PENDING)
-	//if err != nil {
-	//	return nil, err
-	//}
-	//if len(pendingSolROCKMints) == 0 {
+
+	// Check ROCK nonce
 	solParams := k.zentpKeeper.GetSolanaParams(goCtx)
+	k.Logger(ctx).Warn("collectSolanaNonces: checking ROCK nonce", "keyID", solParams.NonceAccountKey)
 	solNonceRequested, err := k.SolanaNonceRequested.Get(goCtx, solParams.NonceAccountKey)
 	if err != nil {
 		if !errors.Is(err, collections.ErrNotFound) {
+			k.Logger(ctx).Warn("collectSolanaNonces: error checking ROCK SolanaNonceRequested", "keyID", solParams.NonceAccountKey, "error", err)
 			return nil, err
 		}
+		k.Logger(ctx).Warn("collectSolanaNonces: ROCK SolanaNonceRequested not found (expected if not needed)", "keyID", solParams.NonceAccountKey)
+		solNonceRequested = false // Explicitly set to false if not found
 	}
-	if solNonceRequested {
-		n, err := k.GetSolanaNonceAccount(goCtx, solParams.NonceAccountKey)
-		nonces[solParams.NonceAccountKey] = &n
-		if err != nil {
-			return nil, err
-		}
-	}
-	//}
+	k.Logger(ctx).Warn("collectSolanaNonces: ROCK SolanaNonceRequested status", "keyID", solParams.NonceAccountKey, "requested", solNonceRequested)
 
-	//ctx := sdk.UnwrapSDKContext(goCtx)
-	//pendingZenBTCMints, err := k.getPendingMintTransactions(ctx, zenbtctypes.MintTransactionStatus_MINT_TRANSACTION_STATUS_STAKED, zenbtctypes.WalletType_WALLET_TYPE_SOLANA)
-	//if err != nil {
-	//	return nil, err
-	//}
-	//if len(pendingZenBTCMints) == 0 {
+	if solNonceRequested {
+		k.Logger(ctx).Warn("collectSolanaNonces: fetching ROCK nonce account", "keyID", solParams.NonceAccountKey)
+		n, err := k.GetSolanaNonceAccount(goCtx, solParams.NonceAccountKey)
+		if err != nil {
+			k.Logger(ctx).Warn("collectSolanaNonces: error fetching ROCK nonce account", "keyID", solParams.NonceAccountKey, "error", err)
+			return nil, err
+		}
+		nonces[solParams.NonceAccountKey] = &n
+		k.Logger(ctx).Warn("collectSolanaNonces: fetched ROCK nonce account", "keyID", solParams.NonceAccountKey, "nonce_value", n.Nonce.String())
+	}
+
+	// Check ZenBTC nonce
 	zenBTCsolParams := k.zenBTCKeeper.GetSolanaParams(goCtx)
+	k.Logger(ctx).Warn("collectSolanaNonces: checking ZenBTC nonce", "keyID", zenBTCsolParams.NonceAccountKey)
 	zenBTCsolNonceRequested, err := k.SolanaNonceRequested.Get(goCtx, zenBTCsolParams.NonceAccountKey)
 	if err != nil {
 		if !errors.Is(err, collections.ErrNotFound) {
+			k.Logger(ctx).Warn("collectSolanaNonces: error checking ZenBTC SolanaNonceRequested", "keyID", zenBTCsolParams.NonceAccountKey, "error", err)
 			return nil, err
 		}
-		zenBTCsolNonceRequested = false
+		k.Logger(ctx).Warn("collectSolanaNonces: ZenBTC SolanaNonceRequested not found (expected if not needed)", "keyID", zenBTCsolParams.NonceAccountKey)
+		zenBTCsolNonceRequested = false // Explicitly set to false if not found
 	}
+	k.Logger(ctx).Warn("collectSolanaNonces: ZenBTC SolanaNonceRequested status", "keyID", zenBTCsolParams.NonceAccountKey, "requested", zenBTCsolNonceRequested)
 
 	if zenBTCsolNonceRequested {
+		k.Logger(ctx).Warn("collectSolanaNonces: fetching ZenBTC nonce account", "keyID", zenBTCsolParams.NonceAccountKey)
 		nonceAcc, err := k.GetSolanaNonceAccount(goCtx, zenBTCsolParams.NonceAccountKey)
 		if err != nil {
+			k.Logger(ctx).Warn("collectSolanaNonces: error fetching ZenBTC nonce account", "keyID", zenBTCsolParams.NonceAccountKey, "error", err)
 			return nil, err
 		}
 		nonces[zenBTCsolParams.NonceAccountKey] = &nonceAcc
+		k.Logger(ctx).Warn("collectSolanaNonces: fetched ZenBTC nonce account", "keyID", zenBTCsolParams.NonceAccountKey, "nonce_value", nonceAcc.Nonce.String())
 	}
-	//}
 
+	k.Logger(ctx).Warn("finished collectSolanaNonces", "collected_count", len(nonces))
 	return nonces, nil
 }
 
 // collectSolanaAccounts retrieves all requested Solana token accounts.
 func (k Keeper) collectSolanaAccounts(ctx context.Context) (map[string]solToken.Account, error) {
+	k.Logger(ctx).Warn("starting collectSolanaAccounts")
 	solAccStore, err := k.SolanaAccountsRequested.Iterate(ctx, nil)
 	if err != nil {
+		k.Logger(ctx).Warn("collectSolanaAccounts: failed to iterate SolanaAccountsRequested", "error", err)
 		return nil, fmt.Errorf("failed to iterate SolanaAccountsRequested: %w", err)
 	}
 	solAccsKeys, err := solAccStore.Keys()
 	if err != nil {
+		k.Logger(ctx).Warn("collectSolanaAccounts: failed to get keys from SolanaAccountsRequested store", "error", err)
 		return nil, fmt.Errorf("failed to get keys from SolanaAccountsRequested store: %w", err)
 	}
+	k.Logger(ctx).Warn("collectSolanaAccounts: found requested account keys", "keys", solAccsKeys)
+
 	solAccs := map[string]solToken.Account{}
 
 	if len(solAccsKeys) > 0 {
+		// TODO: This assumes all requested accounts are for the zentp mint. What about zenBTC?
 		mintAddress := k.zentpKeeper.GetSolanaParams(ctx).MintAddress // Cache mint address
-		for _, key := range solAccsKeys {
+		k.Logger(ctx).Warn("collectSolanaAccounts: using mint address", "mint", mintAddress)
+		for i, key := range solAccsKeys {
+			k.Logger(ctx).Warn("collectSolanaAccounts: processing key", "index", i, "key", key)
 			requested, err := k.SolanaAccountsRequested.Get(ctx, key)
 			if err != nil {
 				if errors.Is(err, collections.ErrNotFound) {
 					// Should not happen if we got the key from Iterate, but handle defensively
-					k.Logger(ctx).Error("key not found during Solana account collection, skipping", "key", key)
+					k.Logger(ctx).Warn("collectSolanaAccounts: key not found during Get, skipping", "key", key)
 					continue
 				}
+				k.Logger(ctx).Warn("collectSolanaAccounts: failed to check if account is requested", "key", key, "error", err)
 				return nil, fmt.Errorf("failed to check if account %s is requested: %w", key, err)
 			}
+			k.Logger(ctx).Warn("collectSolanaAccounts: account requested status", "key", key, "requested", requested)
+
 			if requested {
+				k.Logger(ctx).Warn("collectSolanaAccounts: fetching token account", "key", key, "mint", mintAddress)
 				acc, err := k.GetSolanaTokenAccount(ctx, key, mintAddress)
 				if err != nil {
 					// Log error but continue if possible, maybe one account fetch fails
-					k.Logger(ctx).Error("failed to get Solana token account", "key", key, "mint", mintAddress, "error", err)
+					k.Logger(ctx).Warn("collectSolanaAccounts: failed to get Solana token account", "key", key, "mint", mintAddress, "error", err)
 					// Depending on requirements, might need to return error here instead
 					continue
 				}
 				solAccs[key] = acc
+				k.Logger(ctx).Warn("collectSolanaAccounts: successfully fetched and stored token account", "key", key, "mint", mintAddress, "account_state", int(acc.State), "account_amount", acc.Amount)
 			}
 		}
 	}
 
+	k.Logger(ctx).Warn("finished collectSolanaAccounts", "collected_count", len(solAccs))
 	return solAccs, nil
 }
 
 func (k Keeper) clearSolanaAccounts(ctx sdk.Context) {
+	k.Logger(ctx).Warn("starting clearSolanaAccounts")
 	pendingsROCK, err := k.zentpKeeper.GetMintsWithStatus(ctx, zentptypes.BridgeStatus_BRIDGE_STATUS_PENDING)
 	if err != nil {
-		k.Logger(ctx).Error(err.Error())
+		k.Logger(ctx).Warn("clearSolanaAccounts: error getting pending ROCK mints", "error", err)
+		// Continue checking zenBTC even if ROCK fails
 	}
+	rockCount := 0
+	if pendingsROCK != nil {
+		rockCount = len(pendingsROCK)
+	}
+	k.Logger(ctx).Warn("clearSolanaAccounts: pending ROCK mints check complete", "count", rockCount)
 
 	pendingsZenBTC, err := k.getPendingMintTransactions(ctx, zenbtctypes.MintTransactionStatus_MINT_TRANSACTION_STATUS_STAKED, zenbtctypes.WalletType_WALLET_TYPE_SOLANA)
 	if err != nil {
-		k.Logger(ctx).Error(err.Error())
+		k.Logger(ctx).Warn("clearSolanaAccounts: error getting pending ZenBTC mints", "error", err)
+		// Continue clearing logic even if ZenBTC check fails
 	}
+	zenBTCCount := 0
+	if pendingsZenBTC != nil {
+		zenBTCCount = len(pendingsZenBTC)
+	}
+	k.Logger(ctx).Warn("clearSolanaAccounts: pending ZenBTC mints check complete", "count", zenBTCCount)
 
-	if len(pendingsROCK) == 0 && len(pendingsZenBTC) == 0 {
+	if rockCount == 0 && zenBTCCount == 0 {
+		k.Logger(ctx).Warn("clearSolanaAccounts: no pending Solana mints found, clearing SolanaAccountsRequested store")
 		if err = k.SolanaAccountsRequested.Clear(ctx, nil); err != nil {
-			k.Logger(ctx).Error(err.Error())
+			k.Logger(ctx).Warn("clearSolanaAccounts: error clearing SolanaAccountsRequested store", "error", err)
 		}
+	} else {
+		k.Logger(ctx).Warn("clearSolanaAccounts: pending Solana mints exist, not clearing store", "rock_count", rockCount, "zenbtc_count", zenBTCCount)
 	}
 }

--- a/x/validation/types/expected_keepers.go
+++ b/x/validation/types/expected_keepers.go
@@ -36,9 +36,11 @@ type BankKeeper interface {
 	GetSupply(ctx context.Context, denom string) sdk.Coin
 
 	SendCoinsFromModuleToModule(ctx context.Context, senderPool, recipientPool string, amt sdk.Coins) error
+	SendCoinsFromModuleToAccount(ctx context.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
 	UndelegateCoinsFromModuleToAccount(ctx context.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
 	DelegateCoinsFromAccountToModule(ctx context.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
 
+	MintCoins(ctx context.Context, moduleName string, amt sdk.Coins) error
 	BurnCoins(ctx context.Context, name string, amt sdk.Coins) error
 }
 
@@ -123,4 +125,6 @@ type ZentpKeeper interface {
 	GetSolanaParams(ctx context.Context) *zentptypes.Solana
 	GetMintsWithStatus(goCtx context.Context, status zentptypes.BridgeStatus) ([]*zentptypes.Bridge, error)
 	UpdateMint(ctx context.Context, id uint64, mint *zentptypes.Bridge) error
+	GetBurns(goCtx context.Context, address, chainID, txHash string) ([]*zentptypes.Bridge, error)
+	AddBurn(ctx context.Context, burn *zentptypes.Bridge) error
 }

--- a/x/zentp/keeper/keeper.go
+++ b/x/zentp/keeper/keeper.go
@@ -179,3 +179,16 @@ func (k Keeper) GetMintsWithStatus(goCtx context.Context, status types.BridgeSta
 func (k Keeper) UpdateMint(ctx context.Context, id uint64, mint *types.Bridge) error {
 	return k.mintStore.Set(ctx, id, *mint)
 }
+
+func (k Keeper) AddBurn(ctx context.Context, burn *types.Bridge) error {
+	burnID, err := k.BurnCount.Get(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := k.BurnCount.Set(ctx, burnID+1); err != nil {
+		return err
+	}
+
+	return k.burnStore.Set(ctx, burnID, *burn)
+}

--- a/x/zentp/keeper/msg_server_bridge.go
+++ b/x/zentp/keeper/msg_server_bridge.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/pkg/errors"
 
@@ -14,8 +13,6 @@ import (
 )
 
 func (k msgServer) Bridge(goCtx context.Context, req *types.MsgBridge) (*types.MsgBridgeResponse, error) {
-	return nil, fmt.Errorf("zentp module is currently disabled") // TODO: remove this
-
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	_, err := treasurytypes.Caip2ToKeyType(req.DestinationChain)

--- a/x/zentp/keeper/query_mints_and_burns.go
+++ b/x/zentp/keeper/query_mints_and_burns.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 
+	"cosmossdk.io/collections"
 	"github.com/Zenrock-Foundation/zrchain/v6/x/zentp/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/pkg/errors"
@@ -13,7 +14,7 @@ func (k Keeper) Mints(goCtx context.Context, req *types.QueryMintsRequest) (*typ
 		return nil, errors.New("request is nil")
 	}
 
-	keys, pageRes, err := k.queryBridge(goCtx, req.Pagination, req.Creator, req.Denom, req.Status)
+	keys, pageRes, err := k.queryBridge(goCtx, k.mintStore, req.Pagination, req.Creator, req.Denom, req.Status)
 	if err != nil {
 		return nil, err
 	}
@@ -29,7 +30,7 @@ func (k Keeper) Burns(goCtx context.Context, req *types.QueryBurnsRequest) (*typ
 		return nil, errors.New("request is nil")
 	}
 
-	keys, pageRes, err := k.queryBridge(goCtx, req.Pagination, "", req.Denom, req.Status)
+	keys, pageRes, err := k.queryBridge(goCtx, k.burnStore, req.Pagination, "", req.Denom, req.Status)
 	if err != nil {
 		return nil, err
 	}
@@ -40,10 +41,10 @@ func (k Keeper) Burns(goCtx context.Context, req *types.QueryBurnsRequest) (*typ
 	}, nil
 }
 
-func (k Keeper) queryBridge(goCtx context.Context, pagination *query.PageRequest, creator, denom string, status types.BridgeStatus) ([]*types.Bridge, *query.PageResponse, error) {
+func (k Keeper) queryBridge(goCtx context.Context, store collections.Map[uint64, types.Bridge], pagination *query.PageRequest, creator, denom string, status types.BridgeStatus) ([]*types.Bridge, *query.PageResponse, error) {
 	keys, pageRes, err := query.CollectionFilteredPaginate(
 		goCtx,
-		k.mintStore,
+		store,
 		pagination,
 		func(key uint64, value types.Bridge) (bool, error) {
 			statusMatch := status == types.BridgeStatus_BRIDGE_STATUS_UNSPECIFIED ||

--- a/x/zentp/module/autocli.go
+++ b/x/zentp/module/autocli.go
@@ -17,13 +17,6 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "params",
 					Short:     "Shows the parameters of the module",
 				},
-				{
-					RpcMethod:      "Burns",
-					Use:            "burns [id] [denom]",
-					Short:          "Query burns",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "id"}, {ProtoField: "denom"}},
-				},
-
 				// this line is used by ignite scaffolding # autocli/query
 			},
 		},


### PR DESCRIPTION
* feat: scaffold zentp module

* fix zentp protos

* feat: wire zentp in app.go

* fix: zentp types and pb files

* add relayer keys for minting solROCK and ROCK

* add relayer keys for minting solROCK and ROCK

* rename relayer keys fields

* feat: add MsgMintRock, WIP

* feat: add MsgBurn to zentp module (#146)

* feat: add MsgBurn

* tests: add mocked keepers

* fix: cli and mintRock authority

* fix: let zentp maccaddr receive funds

* fix: add zentp account to ./init script

* feat: key and workspace checks for MsgMintRock

* feat: return error on invalid key

* feat: add msgburnrock shell (#148)

* feat: add msgburnrock shell

* fix: types in message

* feat: MsgMintRock almost complete

* feat: MsgMintRock almost complete

* feat: MsgMintRock almost complete

* feat: work on account info rpc call for solana and other stuff

* wip: multiple keys for transaction requests

* wip: multiple keys for transaction requests

* wip: multiple keys for transaction requests

* feat: recent solana blockhash VE flow

* update `getValidatedOracleData` to properly validate nonce/blockhash fields

* fix: VE flow improvements

* feat: dynamic LamportsPerSignature value sidecar

* wip

* wip

* wip

* wip

* wip

* working solrock mints with one durable nonce, and no tx faiulre handling with timeout

* modify solana nonce accounts to be a map

* zenBTC sol WIP

* solana nonce array impl + sidecar fixes

* add durable_nonce creation test + create keys script

* add mint_Rock.so

* v5->v6 proto fixes

* wip

* working zenbtc mint on solana, still wip

* add migration for signTxRequests (#222)

* add migration for signTxRequests

* add comments to zentp protos

* feat: solana zenbtc redemption flow (#225)

* wip

* wip

* wip

* use correct `TokenRedemptionEventData` type

* dynamic chainID for solana

* feat: add param for SolanaEventScanTxLimit

* refactor `oracle.go`

* add solrockprogramid param

* wip

* wip

* fix: solana redemptions zenbtc (#226)

* add sol burnevents hash to constructVoteExtension

* cleanup

* zenbtc solana mints working

* fix: regen protos

* add upgrade files

* bump zenbtc ver

* fix: add zentp Readme (#224)

* add zentp Readme

* added sidecar context

* update generated files

* fix: `TestGenesis` zentp

* wip

* wip

* bump zenbtc

* comment out generated tests

* address pr comments

* fix solana accounts map init in oracle data

* fix solana accounts map init in oracle data

* tmp

* burns working, need query fixes

* fix zentp burn query

* fix zentp burn query

* fix zentp bugs

* solana account retrieval fixes

* fix solrockparams

* fix solrockparams

* add SolanaMintEventsHash to the VE

* Revert "fix: temporarily disable solana VE flow (#245)"

This reverts commit 750168c98ae171b6562cc35a1cbf68bac7dce6a6.

* merge fixes

* comment out broken test

* fix: update `upgrades.go`

* add solana related logging

* minor fixes

---------